### PR TITLE
Minor fixes for Delphi compilation

### DIFF
--- a/Lib/Fullc_2006.bat
+++ b/Lib/Fullc_2006.bat
@@ -112,6 +112,7 @@ copy *.res ..\..\C10 > nul
 copy *.pas ..\..\C10 > nul
 copy *.dcr ..\..\C10 > nul
 copy *.inc ..\..\C10 > nul
+copy opensslHdrs\*.* ..\..\C10 > nul
 
 cd ..\..\C10
 

--- a/Lib/Fullc_2007.bat
+++ b/Lib/Fullc_2007.bat
@@ -112,6 +112,7 @@ copy *.res ..\..\C11 > nul
 copy *.pas ..\..\C11 > nul
 copy *.dcr ..\..\C11 > nul
 copy *.inc ..\..\C11 > nul
+copy opensslHdrs\*.* ..\..\C11 > nul
 
 cd ..\..\C11
 

--- a/Lib/Fullc_2009.bat
+++ b/Lib/Fullc_2009.bat
@@ -112,6 +112,7 @@ copy *.res ..\..\C12 > nul
 copy *.pas ..\..\C12 > nul
 copy *.dcr ..\..\C12 > nul
 copy *.inc ..\..\C12 > nul
+copy opensslHdrs\*.* ..\..\C12 > nul
 
 cd ..\..\C12
 

--- a/Lib/Fullc_2010.bat
+++ b/Lib/Fullc_2010.bat
@@ -112,6 +112,7 @@ copy *.res ..\..\C14 > nul
 copy *.pas ..\..\C14 > nul
 copy *.dcr ..\..\C14 > nul
 copy *.inc ..\..\C14 > nul
+copy opensslHdrs\*.* ..\..\C14 > nul
 
 cd ..\..\C14
 

--- a/Lib/Fullc_4.bat
+++ b/Lib/Fullc_4.bat
@@ -136,6 +136,7 @@ copy *.res ..\..\C4 > nul
 copy *.pas ..\..\C4 > nul
 copy *.dcr ..\..\C4 > nul
 copy *.inc ..\..\C4 > nul
+copy opensslHdrs\*.* ..\..\C4 > nul
 
 cd ..\..\C4
 

--- a/Lib/Fullc_5.bat
+++ b/Lib/Fullc_5.bat
@@ -136,6 +136,7 @@ copy *.res ..\..\C5 > nul
 copy *.pas ..\..\C5 > nul
 copy *.dcr ..\..\C5 > nul
 copy *.inc ..\..\C5 > nul
+copy opensslHdrs\*.* ..\..\C5 > nul
 
 cd ..\..\C5
 

--- a/Lib/Fullc_6.bat
+++ b/Lib/Fullc_6.bat
@@ -136,6 +136,7 @@ copy *.res ..\..\C6 > nul
 copy *.pas ..\..\C6 > nul
 copy *.dcr ..\..\C6 > nul
 copy *.inc ..\..\C6 > nul
+copy opensslHdrs\*.* ..\..\C6 > nul
 
 cd ..\..\C6
 

--- a/Lib/Fullc_Alexandria.bat
+++ b/Lib/Fullc_Alexandria.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Alexandria.bat
+++ b/Lib/Fullc_Alexandria.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C28 > nul
 copy *.dcr ..\..\C28 > nul
 copy *.inc ..\..\C28 > nul
 copy *.ico ..\..\C28 > nul
+copy opensslHdrs\*.* ..\..\C28 > nul
 
 cd ..\..\C28
 

--- a/Lib/Fullc_Athens.bat
+++ b/Lib/Fullc_Athens.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Athens.bat
+++ b/Lib/Fullc_Athens.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C29 > nul
 copy *.dcr ..\..\C29 > nul
 copy *.inc ..\..\C29 > nul
 copy *.ico ..\..\C29 > nul
+copy opensslHdrs\*.* ..\..\C29 > nul
 
 cd ..\..\C29
 

--- a/Lib/Fullc_Berlin.bat
+++ b/Lib/Fullc_Berlin.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Berlin.bat
+++ b/Lib/Fullc_Berlin.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C24 > nul
 copy *.dcr ..\..\C24 > nul
 copy *.inc ..\..\C24 > nul
 copy *.ico ..\..\C24 > nul
+copy opensslHdrs\*.* ..\..\C24 > nul
 
 cd ..\..\C24
 

--- a/Lib/Fullc_Rio.bat
+++ b/Lib/Fullc_Rio.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C26 > nul
 copy *.dcr ..\..\C26 > nul
 copy *.inc ..\..\C26 > nul
 copy *.ico ..\..\C26 > nul
+copy opensslHdrs\*.* ..\..\C26 > nul
 
 cd ..\..\C26
 

--- a/Lib/Fullc_Rio.bat
+++ b/Lib/Fullc_Rio.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Seattle.bat
+++ b/Lib/Fullc_Seattle.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C23 > nul
 copy *.dcr ..\..\C23 > nul
 copy *.inc ..\..\C23 > nul
 copy *.ico ..\..\C23 > nul
+copy opensslHdrs\*.* ..\..\C23 > nul
 
 cd ..\..\C23
 

--- a/Lib/Fullc_Seattle.bat
+++ b/Lib/Fullc_Seattle.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Sydney.bat
+++ b/Lib/Fullc_Sydney.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Sydney.bat
+++ b/Lib/Fullc_Sydney.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C27 > nul
 copy *.dcr ..\..\C27 > nul
 copy *.inc ..\..\C27 > nul
 copy *.ico ..\..\C27 > nul
+copy opensslHdrs\*.* ..\..\C27 > nul
 
 cd ..\..\C27
 

--- a/Lib/Fullc_Tokyo.bat
+++ b/Lib/Fullc_Tokyo.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_Tokyo.bat
+++ b/Lib/Fullc_Tokyo.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C25 > nul
 copy *.dcr ..\..\C25 > nul
 copy *.inc ..\..\C25 > nul
 copy *.ico ..\..\C25 > nul
+copy opensslHdrs\*.* ..\..\C25 > nul
 
 cd ..\..\C25
 

--- a/Lib/Fullc_XE.bat
+++ b/Lib/Fullc_XE.bat
@@ -112,6 +112,7 @@ copy *.res ..\..\C15 > nul
 copy *.pas ..\..\C15 > nul
 copy *.dcr ..\..\C15 > nul
 copy *.inc ..\..\C15 > nul
+copy opensslHdrs\*.* ..\..\C15 > nul
 
 cd ..\..\C15
 

--- a/Lib/Fullc_XE2.bat
+++ b/Lib/Fullc_XE2.bat
@@ -130,6 +130,7 @@ copy *.pas ..\..\C16 > nul
 copy *.dcr ..\..\C16 > nul
 copy *.inc ..\..\C16 > nul
 copy *.ico ..\..\C16 > nul
+copy opensslHdrs\*.* ..\..\C16 > nul
 
 cd ..\..\C16
 

--- a/Lib/Fullc_XE3.bat
+++ b/Lib/Fullc_XE3.bat
@@ -130,6 +130,7 @@ copy *.pas ..\..\C17 > nul
 copy *.dcr ..\..\C17 > nul
 copy *.inc ..\..\C17 > nul
 copy *.ico ..\..\C17 > nul
+copy opensslHdrs\*.* ..\..\C17 > nul
 
 cd ..\..\C17
 

--- a/Lib/Fullc_XE4.bat
+++ b/Lib/Fullc_XE4.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C18 > nul
 copy *.dcr ..\..\C18 > nul
 copy *.inc ..\..\C18 > nul
 copy *.ico ..\..\C18 > nul
+copy opensslHdrs\*.* ..\..\C18 > nul
 
 cd ..\..\C18
 

--- a/Lib/Fullc_XE5.bat
+++ b/Lib/Fullc_XE5.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_XE5.bat
+++ b/Lib/Fullc_XE5.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C19 > nul
 copy *.dcr ..\..\C19 > nul
 copy *.inc ..\..\C19 > nul
 copy *.ico ..\..\C19 > nul
+copy opensslHdrs\*.* ..\..\C19 > nul
 
 cd ..\..\C19
 

--- a/Lib/Fullc_XE6.bat
+++ b/Lib/Fullc_XE6.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_XE6.bat
+++ b/Lib/Fullc_XE6.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C20 > nul
 copy *.dcr ..\..\C20 > nul
 copy *.inc ..\..\C20 > nul
 copy *.ico ..\..\C20 > nul
+copy opensslHdrs\*.* ..\..\C20 > nul
 
 cd ..\..\C20
 

--- a/Lib/Fullc_XE7.bat
+++ b/Lib/Fullc_XE7.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_XE7.bat
+++ b/Lib/Fullc_XE7.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C21 > nul
 copy *.dcr ..\..\C21 > nul
 copy *.inc ..\..\C21 > nul
 copy *.ico ..\..\C21 > nul
+copy opensslHdrs\*.* ..\..\C21 > nul
 
 cd ..\..\C21
 

--- a/Lib/Fullc_XE7.bat
+++ b/Lib/Fullc_XE7.bat
@@ -172,8 +172,8 @@ REM ************************************************************
 del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
-del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
+REM del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
+REM del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_XE8.bat
+++ b/Lib/Fullc_XE8.bat
@@ -172,7 +172,7 @@ del /Q ..\Output\hpp\%IndyPlatform%\%IndyConfig%\*.*
 del /Q ..\Output\Bpi\%IndyPlatform%\%IndyConfig%\*.*
 if "%IndyPlatform%" == "Win32" del /Q ..\Output\Obj\%IndyPlatform%\%IndyConfig%\*.*
 del /Q "%BDSCOMMONDIR%\Bpl\*Indy*.bpl"
-del /Q "%BDSCOMMONDIR%\Dcp\*.*"
+del /Q "%BDSCOMMONDIR%\Dcp\*Indy*.dcp"
 del /Q ZLib\i386-Win32-ZLib\*.*
 del /Q ZLib\x86_64-Win64-ZLib\*.*
 del /Q *.*

--- a/Lib/Fullc_XE8.bat
+++ b/Lib/Fullc_XE8.bat
@@ -134,6 +134,7 @@ copy *.pas ..\..\C22 > nul
 copy *.dcr ..\..\C22 > nul
 copy *.inc ..\..\C22 > nul
 copy *.ico ..\..\C22 > nul
+copy opensslHdrs\*.* ..\..\C22 > nul
 
 cd ..\..\C22
 

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -286,7 +286,7 @@ uses
 
 type
   TIdSSLVersion = (sslUnknown,sslvSSLv2, sslvSSLv23, sslvSSLv3, sslvTLSv1,sslvTLSv1_1,
-    sslvTLSv1_2, sslvTLSv1_3); {May need to update constants below if adding to this set}
+    sslvTLSv1_2, sslvTLSv1_3);
   TIdSSLVersions = set of TIdSSLVersion;
   TIdSSLMode = (sslmUnassigned, sslmClient, sslmServer, sslmBoth);
   TIdSSLVerifyMode = (sslvrfPeer, sslvrfFailIfNoPeerCert, sslvrfClientOnce);
@@ -297,7 +297,6 @@ type
 const
   DEF_SSLVERSION = sslvTLSv1_2;
   DEF_SSLVERSIONS = [sslvTLSv1_2,sslvTLSv1_3];
-  MAX_SSLVERSION = sslvTLSv1_3;
   P12_FILETYPE = 3;
   MAX_SSL_PASSWORD_LENGTH = 128;
 
@@ -3578,7 +3577,7 @@ begin
   begin
     if SSLVersions <> [] then
     begin
-      for v := sslvSSLv3 to MAX_SSLVERSION do
+      for v := sslvSSLv3 to high(TIdSSLVersions) do
       begin
         if v in SSLVersions then
         begin
@@ -3586,7 +3585,7 @@ begin
           break;
         end;
      end;
-      for v := MAX_SSLVERSION downto sslvSSLv3 do
+      for v := high(TIdSSLVersions) downto sslvSSLv3 do
       begin
         if v in SSLVersions then
         begin

--- a/Lib/Protocols/IdSSLOpenSSL.pas
+++ b/Lib/Protocols/IdSSLOpenSSL.pas
@@ -3577,7 +3577,7 @@ begin
   begin
     if SSLVersions <> [] then
     begin
-      for v := sslvSSLv3 to high(TIdSSLVersions) do
+      for v := sslvSSLv3 to high(TIdSSLVersion) do
       begin
         if v in SSLVersions then
         begin
@@ -3585,7 +3585,7 @@ begin
           break;
         end;
      end;
-      for v := high(TIdSSLVersions) downto sslvSSLv3 do
+      for v := high(TIdSSLVersion) downto sslvSSLv3 do
       begin
         if v in SSLVersions then
         begin

--- a/Lib/Protocols/IdSSLOpenSSLConsts.pas
+++ b/Lib/Protocols/IdSSLOpenSSLConsts.pas
@@ -52,7 +52,7 @@ const
   CLibSSL = 'ssl';
   DirListDelimiter = ':';
   LibSuffix = '.so';
-  DefaultLibVersions = '.3:.1.1:.1.0.2:.1.0.0:.0.9.9:.0.9.8:.0.9.7:.0.9.6';
+  DefaultLibVersions = ':.3:.1.1:.1.0.2:.1.0.0:.0.9.9:.0.9.8:.0.9.7:.0.9.6';
   {$ENDIF}
   {$IFDEF WINDOWS}
   DirListDelimiter = ';';
@@ -68,7 +68,7 @@ const
   {$IFDEF CPU64}
   CLibCrypto = 'libcrypto-3-x64.dll';
   CLibSSL = 'libssl-3-x64.dll';
-  DefaultLibVersions = '-3;-1;';
+  DefaultLibVersions = ';-3-x64;-1-x64';
   {$ENDIF}
   {$IFDEF CPU32}
   CLibCrypto = 'libcrypto-3.dll';

--- a/Lib/Protocols/IndyProtocols100.dpk
+++ b/Lib/Protocols/IndyProtocols100.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols110.dpk
+++ b/Lib/Protocols/IndyProtocols110.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols120.dpk
+++ b/Lib/Protocols/IndyProtocols120.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols130.dpk
+++ b/Lib/Protocols/IndyProtocols130.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols140.dpk
+++ b/Lib/Protocols/IndyProtocols140.dpk
@@ -228,7 +228,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols150.dpk
+++ b/Lib/Protocols/IndyProtocols150.dpk
@@ -228,7 +228,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols150.dproj
+++ b/Lib/Protocols/IndyProtocols150.dproj
@@ -254,7 +254,6 @@
 			<DCCReference Include="IdSNTP.pas"/>
 			<DCCReference Include="IdSSL.pas"/>
 			<DCCReference Include="IdSSLOpenSSL.pas"/>
-			<DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
 			<DCCReference Include="IdSSPI.pas"/>
 			<DCCReference Include="IdServerInterceptLogBase.pas"/>
 			<DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols160.dpk
+++ b/Lib/Protocols/IndyProtocols160.dpk
@@ -246,7 +246,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols160.dproj
+++ b/Lib/Protocols/IndyProtocols160.dproj
@@ -317,7 +317,6 @@
 			<DCCReference Include="IdSNTP.pas"/>
 			<DCCReference Include="IdSSL.pas"/>
 			<DCCReference Include="IdSSLOpenSSL.pas"/>
-			<DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
 			<DCCReference Include="IdSSPI.pas"/>
 			<DCCReference Include="IdServerInterceptLogBase.pas"/>
 			<DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols170.dpk
+++ b/Lib/Protocols/IndyProtocols170.dpk
@@ -248,7 +248,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols170.dproj
+++ b/Lib/Protocols/IndyProtocols170.dproj
@@ -277,7 +277,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols180.dpk
+++ b/Lib/Protocols/IndyProtocols180.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols180.dproj
+++ b/Lib/Protocols/IndyProtocols180.dproj
@@ -304,7 +304,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols190.dpk
+++ b/Lib/Protocols/IndyProtocols190.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols190.dproj
+++ b/Lib/Protocols/IndyProtocols190.dproj
@@ -338,7 +338,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols200.dpk
+++ b/Lib/Protocols/IndyProtocols200.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols200.dproj
+++ b/Lib/Protocols/IndyProtocols200.dproj
@@ -322,7 +322,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols210.dpk
+++ b/Lib/Protocols/IndyProtocols210.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols210.dproj
+++ b/Lib/Protocols/IndyProtocols210.dproj
@@ -350,7 +350,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols220.dpk
+++ b/Lib/Protocols/IndyProtocols220.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols220.dproj
+++ b/Lib/Protocols/IndyProtocols220.dproj
@@ -384,7 +384,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols230.dpk
+++ b/Lib/Protocols/IndyProtocols230.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols230.dproj
+++ b/Lib/Protocols/IndyProtocols230.dproj
@@ -384,7 +384,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols240.dpk
+++ b/Lib/Protocols/IndyProtocols240.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols240.dproj
+++ b/Lib/Protocols/IndyProtocols240.dproj
@@ -292,7 +292,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols250.dpk
+++ b/Lib/Protocols/IndyProtocols250.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols250.dproj
+++ b/Lib/Protocols/IndyProtocols250.dproj
@@ -292,7 +292,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols260.dpk
+++ b/Lib/Protocols/IndyProtocols260.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols260.dproj
+++ b/Lib/Protocols/IndyProtocols260.dproj
@@ -292,7 +292,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols270.dpk
+++ b/Lib/Protocols/IndyProtocols270.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols270.dproj
+++ b/Lib/Protocols/IndyProtocols270.dproj
@@ -292,7 +292,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols280.dpk
+++ b/Lib/Protocols/IndyProtocols280.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols280.dproj
+++ b/Lib/Protocols/IndyProtocols280.dproj
@@ -381,7 +381,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols290.dpk
+++ b/Lib/Protocols/IndyProtocols290.dpk
@@ -257,7 +257,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   {$IFDEF WINDOWS}
   IdSSPI in 'IdSSPI.pas',
   {$ENDIF}

--- a/Lib/Protocols/IndyProtocols290.dproj
+++ b/Lib/Protocols/IndyProtocols290.dproj
@@ -302,7 +302,6 @@
         <DCCReference Include="IdSNTP.pas"/>
         <DCCReference Include="IdSSL.pas"/>
         <DCCReference Include="IdSSLOpenSSL.pas"/>
-        <DCCReference Include="IdSSLOpenSSLHeaders.pas"/>
         <DCCReference Include="IdSSPI.pas"/>
         <DCCReference Include="IdServerInterceptLogBase.pas"/>
         <DCCReference Include="IdServerInterceptLogEvent.pas"/>

--- a/Lib/Protocols/IndyProtocols40.dpk
+++ b/Lib/Protocols/IndyProtocols40.dpk
@@ -226,7 +226,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols50.dpk
+++ b/Lib/Protocols/IndyProtocols50.dpk
@@ -226,7 +226,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols60.dpk
+++ b/Lib/Protocols/IndyProtocols60.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols70.dpk
+++ b/Lib/Protocols/IndyProtocols70.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols80.dpk
+++ b/Lib/Protocols/IndyProtocols80.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocols90.dpk
+++ b/Lib/Protocols/IndyProtocols90.dpk
@@ -228,7 +228,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',

--- a/Lib/Protocols/IndyProtocolsK3.dpk
+++ b/Lib/Protocols/IndyProtocolsK3.dpk
@@ -227,7 +227,6 @@ contains
   IdSNTP in 'IdSNTP.pas',
   IdSSL in 'IdSSL.pas',
   IdSSLOpenSSL in 'IdSSLOpenSSL.pas',
-  IdSSLOpenSSLHeaders in 'IdSSLOpenSSLHeaders.pas',
   IdSSPI in 'IdSSPI.pas',
   IdServerInterceptLogBase in 'IdServerInterceptLogBase.pas',
   IdServerInterceptLogEvent in 'IdServerInterceptLogEvent.pas',


### PR DESCRIPTION
Minor fixes to Delphi compilation (checked only on Delphi XE7 but should work with other Delphi versions)
- Alternative fix to https://github.com/MWASoftware/Indy.proposedUpdate/commit/e50fdd0244ab9a7b0b2a6d77d2abe520bc4b3a1f without introduction of additional constant MAX_SSLVERSION
(High function does not work with set types but works fine with enumeration types)
- Removed references to IdSSLOpenSSLHeaders.pas from *.dpk and *.dproj as those files do not exist anymore.
- Changed handling of files in "%BDSCOMMONDIR%/Bpl" and "%BDSCOMMONDIR%/Dcp" directories.
In Lib/Fullc_XE7.bat disabled removal of *Indy*.bpl and *Indy*.dcp files completely as I don't see any reason why those files should be removed from %BDSCOMMONDIR%.